### PR TITLE
release: build linux binary with musl for static linking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
           - target: aarch64-apple-darwin
             runner: macos-latest
@@ -38,6 +38,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Install musl tools (Linux only)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get install -y musl-tools
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
Switches the Linux build target from `x86_64-unknown-linux-gnu` to `x86_64-unknown-linux-musl` to produce a statically-linked binary with no glibc dependency. The `gnu` build requires `GLIBC_2.38` which isn't available on older systems (e.g. Debian Bookworm ships 2.36).

Changes:
- Target: `x86_64-unknown-linux-gnu` → `x86_64-unknown-linux-musl`
- Added `musl-tools` install step (Linux runner only)
- Added `rustup target add` step for the musl target

🤖 Generated with [Claude Code](https://claude.ai/claude-code)