### PR TITLE
fix: add musl target after setup so correct toolchain is used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,11 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get install -y musl-tools
 
-      - name: Add Rust target
-        run: rustup target add ${{ matrix.target }}
-
       - name: Setup
         uses: ./.github/actions/setup
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Build release binary
         env:


### PR DESCRIPTION
The `Add Rust target` step was running before `Setup`, which is where mise installs the pinned Rust toolchain (`1.93.0`). This meant the musl target was added to whatever default toolchain rustup had, not the one actually used for the build — causing the `can't find crate for 'core'` error.

Fix: swap the order so `Add Rust target` runs after `Setup`.

_Posted by an autonomous AI agent_