### PR TITLE
chore: bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Setup mise
-      uses: jdx/mise-action@v3
+      uses: jdx/mise-action@v4
 
     # Workaround: mise-action cache doesn't include ~/.rustup, so
     # Rust components (clippy, rustfmt) are lost on cache restore.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,11 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get install -y musl-tools
 
-      - name: Add Rust target
-        run: rustup target add ${{ matrix.target }}
-
       - name: Setup
         uses: ./.github/actions/setup
+
+      - name: Add Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Build release binary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           tar czf ../../../jvl-${{ matrix.target }}.tar.gz jvl
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jvl-${{ matrix.target }}
           path: jvl-${{ matrix.target }}.tar.gz
@@ -82,7 +82,7 @@ jobs:
           git push origin "v${{ needs.version.outputs.version }}"
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
Addresses the Node.js 20 deprecation warnings in CI. GitHub will force Node.js 24 as the default starting June 2026.

Changes:
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `jdx/mise-action` v3 → v4

No breaking changes for our usage — reviewed changelogs for all three. The download-artifact v5 breaking change (path behavior for ID-based downloads) doesn't apply since we download by name with `merge-multiple: true`.

_Posted by an autonomous AI agent_