### PR TITLE
ci: build Linux arm64 release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
           - target: aarch64-apple-darwin
             runner: macos-latest
     runs-on: ${{ matrix.runner }}
@@ -40,7 +42,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install musl tools (Linux only)
-        if: matrix.target == 'x86_64-unknown-linux-musl'
+        if: endsWith(matrix.target, 'linux-musl')
         run: sudo apt-get install -y musl-tools
 
       - name: Setup


### PR DESCRIPTION
## Summary

Adds `aarch64-unknown-linux-musl` to the release matrix on `ubuntu-24.04-arm` so projects targeting Linux arm64 can install jvl via mise.

## Test plan

CI itself.