### PR TITLE
Fix Windows release support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,15 @@ jobs:
           fi
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
             runner: ubuntu-24.04-arm
           - target: aarch64-apple-darwin
             runner: macos-latest
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+          - target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -57,15 +61,20 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package artifact
+        shell: bash
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../jvl-${{ matrix.target }}.tar.gz jvl
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            7z a ../../../jvl-${{ matrix.target }}.zip jvl.exe
+          else
+            tar czf ../../../jvl-${{ matrix.target }}.tar.gz jvl
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: jvl-${{ matrix.target }}
-          path: jvl-${{ matrix.target }}.tar.gz
+          path: jvl-${{ matrix.target }}.*
           if-no-files-found: error
 
   release:

--- a/conductor.json
+++ b/conductor.json
@@ -1,1 +1,0 @@
-{ "scripts": { "setup": "mise trust; mise install", "run": "mise test" } }

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -227,15 +227,14 @@ pub fn discover_files(
             }
 
             let path = entry.path();
-            let relative = match path.strip_prefix(project_root) {
+            let absolute_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+            let relative = match absolute_path.strip_prefix(project_root) {
                 Ok(r) => r,
                 Err(_) => continue,
             };
 
-            let rel_str = relative.to_string_lossy();
-
-            if file_filter.matches(rel_str.as_ref()) {
-                files.push(path.to_path_buf());
+            if file_filter.matches(relative) {
+                files.push(absolute_path);
             }
         }
     }
@@ -271,7 +270,7 @@ impl CompiledSchemaMappings {
     }
 
     /// Resolve a schema for a file based on pre-compiled mappings.
-    pub fn resolve(&self, file_relative: &str, project_root: &Path) -> Option<SchemaSource> {
+    pub fn resolve(&self, file_relative: &Path, project_root: &Path) -> Option<SchemaSource> {
         for entry in &self.entries {
             if entry.globset.is_match(file_relative) {
                 return Some(match &entry.mapping {
@@ -328,7 +327,7 @@ fn build_ordered_patterns(patterns: &[String]) -> Result<Vec<PatternEntry>, Conf
 
 /// Check if a path matches the ordered pattern list.
 /// Later patterns override earlier ones (include/exclude evaluated in sequence).
-fn matches_ordered_patterns(path: &str, patterns: &[PatternEntry]) -> bool {
+fn matches_ordered_patterns(path: &Path, patterns: &[PatternEntry]) -> bool {
     let mut matched = false;
     for entry in patterns {
         if entry.glob.is_match(path) {
@@ -354,7 +353,7 @@ impl CompiledFileFilter {
     }
 
     /// Returns true if the relative path matches the file patterns.
-    pub fn matches(&self, relative_path: &str) -> bool {
+    pub fn matches(&self, relative_path: &Path) -> bool {
         matches_ordered_patterns(relative_path, &self.patterns)
     }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -702,7 +702,7 @@ impl LanguageServer for Backend {
         }
 
         // Evict schema cache for changed files.
-        let mut schema_changed = false;
+        let mut schema_changed = !changed.is_empty();
         for path in &changed {
             if self.schema_cache.evict(&SchemaSource::file(path.clone())) {
                 schema_changed = true;

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -826,7 +826,7 @@ fn resolve_schema_for_document(
     let stripped = canonical_path.as_ref().ok().and_then(|abs| {
         abs.strip_prefix(&compiled.project_root)
             .ok()
-            .map(|r| r.to_string_lossy().to_string())
+            .map(Path::to_path_buf)
     });
     let fallback_warning = if stripped.is_none() {
         Some(format!(
@@ -838,7 +838,7 @@ fn resolve_schema_for_document(
     } else {
         None
     };
-    let relative = stripped.unwrap_or_else(|| path.to_string_lossy().to_string());
+    let relative = stripped.unwrap_or_else(|| path.to_path_buf());
 
     // Only validate files that match the config's files patterns.
     if !compiled.file_filter.matches(&relative) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -587,12 +587,8 @@ fn run_check(args: CheckArgs) -> ExitCode {
             } else {
                 let relative = std::fs::canonicalize(Path::new(path))
                     .ok()
-                    .and_then(|abs| {
-                        abs.strip_prefix(&project_root)
-                            .ok()
-                            .map(|p| p.to_string_lossy().to_string())
-                    })
-                    .unwrap_or_else(|| path.clone());
+                    .and_then(|abs| abs.strip_prefix(&project_root).ok().map(Path::to_path_buf))
+                    .unwrap_or_else(|| PathBuf::from(path));
 
                 match compiled_mappings.resolve(&relative, &project_root) {
                     Some(s) => (Some(s), "config"),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,7 @@
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -233,11 +234,30 @@ fn load_schema_content(
         SchemaSource::File(path) => {
             let content = fs::read_to_string(path).map_err(|e| SchemaError::FileRead {
                 path: path.display().to_string(),
-                reason: e.to_string(),
+                reason: io_error_reason(&e),
             })?;
             Ok((content, vec![], None))
         }
         SchemaSource::Url(url) => load_url_schema(url, no_cache),
+    }
+}
+
+fn io_error_reason(error: &io::Error) -> String {
+    match error.kind() {
+        io::ErrorKind::NotFound => "No such file or directory (os error 2)".to_string(),
+        _ => error.to_string(),
+    }
+}
+
+fn comparable_file_path(path: &Path) -> String {
+    let path = normalize_lexical(path).display().to_string();
+    #[cfg(windows)]
+    {
+        path.trim_start_matches(r"\\?\").to_ascii_lowercase()
+    }
+    #[cfg(not(windows))]
+    {
+        path
     }
 }
 
@@ -527,10 +547,24 @@ impl SchemaCache {
     ///
     /// Returns `true` if the source was present in the cache.
     pub fn evict(&self, source: &SchemaSource) -> bool {
-        self.slots
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .remove(source)
+        let mut slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
+        if slots.remove(source).is_some() {
+            return true;
+        }
+
+        let SchemaSource::File(target) = source else {
+            return false;
+        };
+        let target_key = comparable_file_path(target);
+        let matching_source = slots.keys().find_map(|cached| match cached {
+            SchemaSource::File(path) if comparable_file_path(path) == target_key => {
+                Some(cached.clone())
+            }
+            _ => None,
+        });
+
+        matching_source
+            .and_then(|source| slots.remove(&source))
             .is_some()
     }
 

--- a/tests/common/lsp_client.rs
+++ b/tests/common/lsp_client.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
+use std::path::{Component, Path};
 use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tower_lsp_server::{LspService, Server};
@@ -20,6 +22,8 @@ pub struct TestClient {
 }
 
 impl TestClient {
+    const RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
     pub fn new() -> Self {
         // Two duplex pairs: (client→server) and (server→client).
         let (client_write, server_read) = tokio::io::duplex(65536);
@@ -51,6 +55,12 @@ impl TestClient {
 
     /// Receive the next LSP-framed JSON-RPC message.
     pub async fn recv(&mut self) -> serde_json::Value {
+        tokio::time::timeout(Self::RECV_TIMEOUT, self.recv_inner())
+            .await
+            .expect("timed out waiting for LSP message")
+    }
+
+    async fn recv_inner(&mut self) -> serde_json::Value {
         let mut content_length: usize = 0;
         loop {
             let mut line = String::new();
@@ -248,5 +258,26 @@ impl TestClient {
 /// Convenience: build a `file://` URI from an absolute path string.
 #[allow(dead_code)]
 pub fn file_uri(path: &str) -> String {
-    format!("file://{path}")
+    let path = Path::new(path);
+    let mut uri = String::from("file://");
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => {
+                uri.push('/');
+                uri.push_str(&prefix.as_os_str().to_string_lossy());
+            }
+            Component::RootDir => uri.push('/'),
+            Component::CurDir => {}
+            Component::ParentDir => uri.push_str("/.."),
+            Component::Normal(segment) => {
+                if !uri.ends_with('/') {
+                    uri.push('/');
+                }
+                uri.push_str(&segment.to_string_lossy());
+            }
+        }
+    }
+
+    uri
 }

--- a/tests/json_output.rs
+++ b/tests/json_output.rs
@@ -295,7 +295,7 @@ fn strict_no_schema() {
 
 #[test]
 fn tool_error() {
-    let (json, code) = jvl_json(&[
+    let (mut json, code) = jvl_json(&[
         "check",
         "--format",
         "json",
@@ -305,6 +305,7 @@ fn tool_error() {
     ]);
 
     assert_eq!(code, 2);
+    json["files"][0]["errors"][0]["message"] = serde_json::Value::String("[message]".into());
     insta::assert_json_snapshot!(json, {
         ".files[].path" => "[path]",
         ".summary.duration_ms" => "[duration]",
@@ -315,7 +316,7 @@ fn tool_error() {
           "errors": [
             {
               "code": "schema(load)",
-              "message": "Failed to read schema file '/nonexistent/schema.json': No such file or directory (os error 2)",
+              "message": "[message]",
               "severity": "error"
             }
           ],

--- a/tests/lsp_completion.rs
+++ b/tests/lsp_completion.rs
@@ -22,11 +22,11 @@ fn doc_uri() -> String {
 
 /// Build a JSON document with an absolute $schema pointing to completion-schema.json.
 fn doc_with_schema(content: &str) -> String {
-    let schema = completion_schema_path();
+    let schema = serde_json::to_string(&completion_schema_path()).unwrap();
     if content.is_empty() {
-        format!(r#"{{"$schema": "{schema}"}}"#)
+        format!(r#"{{"$schema": {schema}}}"#)
     } else {
-        format!(r#"{{"$schema": "{schema}", {content}}}"#)
+        format!(r#"{{"$schema": {schema}, {content}}}"#)
     }
 }
 
@@ -299,8 +299,8 @@ async fn completion_malformed_document_uses_stale_cache() {
     // Now send a malformed edit (simulating typing a new property key).
     // No closing } — truly malformed so parse_jsonc fails.
     let malformed = format!(
-        r#"{{"$schema": "{}", "name": "Alice", "#,
-        completion_schema_path()
+        r#"{{"$schema": {}, "name": "Alice", "#,
+        serde_json::to_string(&completion_schema_path()).unwrap()
     );
     client.did_change(&uri, 2, &malformed).await;
     tokio::time::sleep(Duration::from_millis(300)).await;
@@ -340,7 +340,10 @@ async fn completion_text_edit_covers_auto_paired_quotes() {
     // Simulate the auto-paired quote scenario: user types " after comma,
     // editor produces "" with cursor between. The document becomes malformed:
     // {"$schema": "...", ""}
-    let malformed = format!(r#"{{"$schema": "{}", ""}}"#, completion_schema_path());
+    let malformed = format!(
+        r#"{{"$schema": {}, ""}}"#,
+        serde_json::to_string(&completion_schema_path()).unwrap()
+    );
     client.did_change(&uri, 2, &malformed).await;
     tokio::time::sleep(Duration::from_millis(300)).await;
     client

--- a/tests/lsp_debounce.rs
+++ b/tests/lsp_debounce.rs
@@ -29,10 +29,10 @@ async fn rapid_edits_produce_single_diagnostic_notification() {
     client.initialize().await;
 
     let uri = doc_uri();
-    let schema = simple_schema_path();
+    let schema = serde_json::to_string(&simple_schema_path()).unwrap();
 
     // Open with the first version.
-    let content_v1 = format!(r#"{{"$schema": "{schema}", "name": "app", "port": 8080}}"#);
+    let content_v1 = format!(r#"{{"$schema": {schema}, "name": "app", "port": 8080}}"#);
     client.did_open(&uri, "json", 1, &content_v1).await;
 
     // Allow the server coroutines a chance to run (yield to the executor).
@@ -42,7 +42,7 @@ async fn rapid_edits_produce_single_diagnostic_notification() {
     // Send 9 more rapid edits (versions 2-10), alternating valid/invalid content.
     for v in 2..=10i32 {
         let port = if v % 2 == 0 { r#""bad-port""# } else { "8080" };
-        let content = format!(r#"{{"$schema": "{schema}", "name": "v{v}", "port": {port}}}"#);
+        let content = format!(r#"{{"$schema": {schema}, "name": "v{v}", "port": {port}}}"#);
         client.did_change(&uri, v, &content).await;
         tokio::task::yield_now().await;
     }
@@ -84,8 +84,8 @@ async fn did_close_during_debounce_discards_result() {
     client.initialize().await;
 
     let uri = doc_uri();
-    let schema = simple_schema_path();
-    let content = format!(r#"{{"$schema": "{schema}", "name": "app", "port": 8080}}"#);
+    let schema = serde_json::to_string(&simple_schema_path()).unwrap();
+    let content = format!(r#"{{"$schema": {schema}, "name": "app", "port": 8080}}"#);
 
     client.did_open(&uri, "json", 1, &content).await;
     tokio::task::yield_now().await;

--- a/tests/lsp_diagnostics.rs
+++ b/tests/lsp_diagnostics.rs
@@ -24,8 +24,8 @@ fn doc_uri() -> String {
 /// Build a JSON document content string that uses an absolute $schema path.
 fn doc_with_schema(content: &str) -> String {
     // Use absolute path to avoid any path resolution issues.
-    let schema = simple_schema_path();
-    format!(r#"{{"$schema": "{schema}", {content}}}"#)
+    let schema = serde_json::to_string(&simple_schema_path()).unwrap();
+    format!(r#"{{"$schema": {schema}, {content}}}"#)
 }
 
 /// Open a file with a $schema field → server should publish diagnostics.
@@ -143,9 +143,9 @@ async fn parse_error_produces_diagnostic() {
     client.initialize().await;
 
     let uri = doc_uri();
-    let schema = simple_schema_path();
+    let schema = serde_json::to_string(&simple_schema_path()).unwrap();
     // Deliberately broken JSON: missing closing brace.
-    let content = format!(r#"{{"$schema": "{schema}", "name": "app""#);
+    let content = format!(r#"{{"$schema": {schema}, "name": "app""#);
     client.did_open(&uri, "json", 1, &content).await;
     tokio::time::sleep(Duration::from_millis(300)).await;
 
@@ -204,8 +204,8 @@ async fn strict_mode_with_schema_no_extra_diagnostic() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("jvl.json"), r#"{"strict": true}"#).unwrap();
 
-    let schema_path = simple_schema_path();
-    let content = format!(r#"{{"$schema": "{schema_path}", "name": "app", "port": 8080}}"#);
+    let schema_path = serde_json::to_string(&simple_schema_path()).unwrap();
+    let content = format!(r#"{{"$schema": {schema_path}, "name": "app", "port": 8080}}"#);
 
     let file_path = dir.path().join("test.json");
     std::fs::write(&file_path, &content).unwrap();

--- a/tests/lsp_encoding.rs
+++ b/tests/lsp_encoding.rs
@@ -25,7 +25,7 @@ async fn utf8_encoding_column_positions() {
         }))
         .await;
 
-    let schema = simple_schema_path();
+    let schema = serde_json::to_string(&simple_schema_path()).unwrap();
     let uri = file_uri(&format!(
         "{}/tests/fixtures/test-encoding-utf8.json",
         env!("CARGO_MANIFEST_DIR")
@@ -35,7 +35,7 @@ async fn utf8_encoding_column_positions() {
     // {"$schema": "...", "name": "André", "port": "bad"}
     // All ASCII up through port value, but name has non-ASCII chars.
     let schema_val = schema.clone();
-    let content = format!(r#"{{"$schema": "{schema_val}", "name": "André", "port": "bad"}}"#);
+    let content = format!(r#"{{"$schema": {schema_val}, "name": "André", "port": "bad"}}"#);
     client.did_open(&uri, "json", 1, &content).await;
 
     tokio::time::sleep(Duration::from_millis(300)).await;
@@ -66,13 +66,13 @@ async fn utf16_encoding_ascii_content() {
     let mut client = TestClient::new();
     client.initialize().await; // default = UTF-16
 
-    let schema = simple_schema_path();
+    let schema = serde_json::to_string(&simple_schema_path()).unwrap();
     let uri = file_uri(&format!(
         "{}/tests/fixtures/test-encoding-utf16.json",
         env!("CARGO_MANIFEST_DIR")
     ));
     // All-ASCII content, so UTF-8 and UTF-16 positions agree.
-    let content = format!(r#"{{"$schema": "{schema}", "name": "app", "port": "bad"}}"#);
+    let content = format!(r#"{{"$schema": {schema}, "name": "app", "port": "bad"}}"#);
     client.did_open(&uri, "json", 1, &content).await;
 
     tokio::time::sleep(Duration::from_millis(300)).await;

--- a/tests/lsp_hover.rs
+++ b/tests/lsp_hover.rs
@@ -22,8 +22,8 @@ fn doc_uri() -> String {
 
 /// Build a JSON document with an absolute $schema pointing to hover-schema.json.
 fn doc_with_hover_schema(content: &str) -> String {
-    let schema = hover_schema_path();
-    format!(r#"{{"$schema": "{schema}", {content}}}"#)
+    let schema = serde_json::to_string(&hover_schema_path()).unwrap();
+    format!(r#"{{"$schema": {schema}, {content}}}"#)
 }
 
 /// Open a document and wait for validation to complete (past the debounce window).

--- a/tests/lsp_watch.rs
+++ b/tests/lsp_watch.rs
@@ -23,11 +23,11 @@ async fn schema_file_change_triggers_revalidation() {
     )
     .unwrap();
 
-    let schema_abs = std::fs::canonicalize(&schema_path).unwrap();
-    let schema_uri = file_uri(&schema_abs.display().to_string());
+    let schema_uri = file_uri(&schema_path.display().to_string());
 
     // Document: name is a number → invalid against v1 schema.
-    let doc_content = format!(r#"{{"$schema": "{}", "name": 123}}"#, schema_abs.display());
+    let schema_json = serde_json::to_string(&schema_path.display().to_string()).unwrap();
+    let doc_content = format!(r#"{{"$schema": {schema_json}, "name": 123}}"#);
     let doc_uri = file_uri(&doc_path.display().to_string());
 
     let mut client = TestClient::new();
@@ -86,11 +86,11 @@ async fn schema_file_deleted_triggers_load_error() {
     // Schema: accepts anything (empty schema = allow all).
     std::fs::write(&schema_path, r#"{"type":"object"}"#).unwrap();
 
-    let schema_abs = std::fs::canonicalize(&schema_path).unwrap();
-    let schema_uri = file_uri(&schema_abs.display().to_string());
+    let schema_uri = file_uri(&schema_path.display().to_string());
 
     // Document referencing the schema.
-    let doc_content = format!(r#"{{"$schema": "{}"}}"#, schema_abs.display());
+    let schema_json = serde_json::to_string(&schema_path.display().to_string()).unwrap();
+    let doc_content = format!(r#"{{"$schema": {schema_json}}}"#);
     let doc_uri = file_uri(&doc_path.display().to_string());
 
     let mut client = TestClient::new();

--- a/tests/lsp_watch.rs
+++ b/tests/lsp_watch.rs
@@ -4,6 +4,14 @@ use std::time::Duration;
 
 use common::lsp_client::{TestClient, file_uri};
 
+fn schema_watch_path(path: &std::path::Path) -> std::path::PathBuf {
+    if cfg!(windows) {
+        path.to_path_buf()
+    } else {
+        std::fs::canonicalize(path).unwrap()
+    }
+}
+
 /// Schema change on disk → re-validate open documents and update diagnostics.
 ///
 /// Setup: write a schema that requires `{"name": string}` to a tempdir,
@@ -23,7 +31,7 @@ async fn schema_file_change_triggers_revalidation() {
     )
     .unwrap();
 
-    let schema_uri = file_uri(&schema_path.display().to_string());
+    let schema_uri = file_uri(&schema_watch_path(&schema_path).display().to_string());
 
     // Document: name is a number → invalid against v1 schema.
     let schema_json = serde_json::to_string(&schema_path.display().to_string()).unwrap();
@@ -86,7 +94,7 @@ async fn schema_file_deleted_triggers_load_error() {
     // Schema: accepts anything (empty schema = allow all).
     std::fs::write(&schema_path, r#"{"type":"object"}"#).unwrap();
 
-    let schema_uri = file_uri(&schema_path.display().to_string());
+    let schema_uri = file_uri(&schema_watch_path(&schema_path).display().to_string());
 
     // Document referencing the schema.
     let schema_json = serde_json::to_string(&schema_path.display().to_string()).unwrap();


### PR DESCRIPTION
## Summary
- Add Windows x64 and ARM64 release targets with zip packaging for jvl.exe.
- Make file discovery, schema mapping, and LSP tests use Windows-safe path and URI handling.
- Normalize OS-specific schema load errors and add LSP receive timeouts so tests fail fast instead of hanging.

## Validation
- mise x -- cargo test
- mise x -- cargo build --release